### PR TITLE
[VCHCK-320] 🎨 (Base) Add grommet theme wrapper to component stories generator

### DIFF
--- a/internals/generators/component/Component.stories.js.hbs
+++ b/internals/generators/component/Component.stories.js.hbs
@@ -1,7 +1,12 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
+import { Grommet } from 'grommet'
 
+import theme from '../../../utils/theme'
 import {{ properCase name }} from '../{{ properCase name }}'
 
-storiesOf("{{ properCase name }}", module).add("Default", () =>
-< {{ properCase name }} />)
+storiesOf("{{ properCase name }}", module).add("Default", () => (
+<Grommet theme={theme}>
+    <{{ properCase name }} />
+</Grommet>
+))


### PR DESCRIPTION
## Feature

Add grommet theme wrapper to Component.stories.js.hbs so that grommet theme is included in all new components created with the generator

## Approach

Import Grommet and theme into stories generator file
Add wrapper around component
