### PR TITLE
[CUTL-140] ✨ (FormField) Pass down the `name` prop to children

### DIFF
--- a/app/components/Form/FormField.js
+++ b/app/components/Form/FormField.js
@@ -25,9 +25,7 @@ export const StyledFormField = styled(GrommetFormField)`
  *
  * - If the field is marked as `required`, add an asterisk (*) to its label
  */
-const FormField = (props) => {
-  const { children, label, name, required, serverSideRequired, value, ...rest } = props
-
+const FormField = ({ children, label, name, required, serverSideRequired, value, ...rest }) => {
   /**
    * Configure the children to pass down in the `FormField`.
    * - If there is a `name`, and the `children` are not an array, clone them and pass down the `name` prop.

--- a/app/components/Form/FormField.js
+++ b/app/components/Form/FormField.js
@@ -1,7 +1,9 @@
 /* eslint-disable react/prop-types */
+/* eslint-disable react/jsx-props-no-spreading */
 import React from 'react'
 import { FormField as GrommetFormField } from 'grommet'
 import styled from 'styled-components'
+import _ from 'lodash'
 
 // Components
 import { Text } from '../Text'
@@ -23,8 +25,20 @@ export const StyledFormField = styled(GrommetFormField)`
  *
  * - If the field is marked as `required`, add an asterisk (*) to its label
  */
-const FormField = props => {
-  const { label, required, serverSideRequired, value, children, ...rest } = props
+const FormField = (props) => {
+  const { children, label, name, required, serverSideRequired, value, ...rest } = props
+
+  /**
+   * Configure the children to pass down in the `FormField`.
+   * - If there is a `name`, and the `children` are not an array, clone them and pass down the `name` prop.
+   */
+  const configureChildren = () => {
+    if (name && _.isObject(children) && !_.isArray(children))
+      return React.cloneElement(children, { name })
+
+    return children
+  }
+
   return (
     <StyledFormField
       label={
@@ -41,11 +55,12 @@ const FormField = props => {
           </Text>
         )
       }
+      name={name}
       required={required}
       {...value}
       {...rest}
     >
-      {children}
+      {configureChildren()}
     </StyledFormField>
   )
 }

--- a/app/pages/Login/Login.js
+++ b/app/pages/Login/Login.js
@@ -80,7 +80,7 @@ const Login = ({ location }) => {
             name="email"
             required
             validate={[
-              (email) => {
+              email => {
                 if (email && !isEmail(email)) return 'Please enter a valid email address'
                 return undefined
               },
@@ -94,7 +94,7 @@ const Login = ({ location }) => {
             name="password"
             required
             validate={[
-              (password) => {
+              password => {
                 if (password && password.length <= 8) return 'Please enter more than 8 characters'
                 return undefined
               },

--- a/app/pages/Login/Login.js
+++ b/app/pages/Login/Login.js
@@ -80,13 +80,13 @@ const Login = ({ location }) => {
             name="email"
             required
             validate={[
-              email => {
+              (email) => {
                 if (email && !isEmail(email)) return 'Please enter a valid email address'
                 return undefined
               },
             ]}
           >
-            <TextInput name="email" type="email" />
+            <TextInput type="email" />
           </FormField>
 
           <FormField
@@ -94,13 +94,13 @@ const Login = ({ location }) => {
             name="password"
             required
             validate={[
-              password => {
+              (password) => {
                 if (password && password.length <= 8) return 'Please enter more than 8 characters'
                 return undefined
               },
             ]}
           >
-            <PasswordInput id="password" name="password" />
+            <PasswordInput id="password" />
           </FormField>
 
           {/* Submit */}

--- a/app/pages/PasswordReset/PasswordReset.js
+++ b/app/pages/PasswordReset/PasswordReset.js
@@ -158,11 +158,11 @@ const PasswordReset = observer(({ location }) => {
             name="password"
             required
             validate={[
-              password => {
+              (password) => {
                 if (password && password.length <= 8) return 'Please enter more than 8 characters'
                 return undefined
               },
-              password => {
+              (password) => {
                 const confirmPasswordInput = document.getElementsByName('confirm_password')[0]
                 if (
                   password &&
@@ -175,7 +175,7 @@ const PasswordReset = observer(({ location }) => {
               },
             ]}
           >
-            <PasswordInput id="password" name="password" />
+            <PasswordInput id="password" />
           </FormField>
 
           <FormField
@@ -183,12 +183,12 @@ const PasswordReset = observer(({ location }) => {
             name="confirm_password"
             required
             validate={[
-              confirmPassword => {
+              (confirmPassword) => {
                 if (confirmPassword && confirmPassword.length <= 8)
                   return 'Please enter more than 8 characters'
                 return undefined
               },
-              confirmPassword => {
+              (confirmPassword) => {
                 const passwordInput = document.getElementsByName('password')[0]
 
                 if (
@@ -202,7 +202,7 @@ const PasswordReset = observer(({ location }) => {
               },
             ]}
           >
-            <PasswordInput name="confirm_password" />
+            <PasswordInput />
           </FormField>
 
           {/* TOS */}

--- a/app/pages/PasswordReset/PasswordReset.js
+++ b/app/pages/PasswordReset/PasswordReset.js
@@ -158,11 +158,11 @@ const PasswordReset = observer(({ location }) => {
             name="password"
             required
             validate={[
-              (password) => {
+              password => {
                 if (password && password.length <= 8) return 'Please enter more than 8 characters'
                 return undefined
               },
-              (password) => {
+              password => {
                 const confirmPasswordInput = document.getElementsByName('confirm_password')[0]
                 if (
                   password &&
@@ -183,12 +183,12 @@ const PasswordReset = observer(({ location }) => {
             name="confirm_password"
             required
             validate={[
-              (confirmPassword) => {
+              confirmPassword => {
                 if (confirmPassword && confirmPassword.length <= 8)
                   return 'Please enter more than 8 characters'
                 return undefined
               },
-              (confirmPassword) => {
+              confirmPassword => {
                 const passwordInput = document.getElementsByName('password')[0]
 
                 if (

--- a/app/pages/PasswordResetRequest/PasswordResetRequest.js
+++ b/app/pages/PasswordResetRequest/PasswordResetRequest.js
@@ -55,13 +55,13 @@ const PasswordResetRequest = () => {
             name="email"
             required
             validate={[
-              email => {
+              (email) => {
                 if (email && !isEmail(email)) return 'Please enter a valid email address'
                 return undefined
               },
             ]}
           >
-            <TextInput name="email" type="email" />
+            <TextInput type="email" />
           </FormField>
 
           {/* Submit */}

--- a/app/pages/PasswordResetRequest/PasswordResetRequest.js
+++ b/app/pages/PasswordResetRequest/PasswordResetRequest.js
@@ -55,7 +55,7 @@ const PasswordResetRequest = () => {
             name="email"
             required
             validate={[
-              (email) => {
+              email => {
                 if (email && !isEmail(email)) return 'Please enter a valid email address'
                 return undefined
               },

--- a/app/pages/Register/Register.js
+++ b/app/pages/Register/Register.js
@@ -69,7 +69,7 @@ const Register = () => {
               required
               style={{ flex: 1 }}
               validate={[
-                name => {
+                (name) => {
                   if (name && name.length === 1) return 'Please enter more than one character'
                   return undefined
                 },
@@ -82,7 +82,7 @@ const Register = () => {
               required
               style={{ flex: 1 }}
               validate={[
-                name => {
+                (name) => {
                   if (name && name.length === 1) return 'Please enter more than one character'
                   return undefined
                 },
@@ -95,13 +95,13 @@ const Register = () => {
             name="email"
             required
             validate={[
-              email => {
+              (email) => {
                 if (email && !isEmail(email)) return 'Please enter a valid email address'
                 return undefined
               },
             ]}
           >
-            <TextInput name="email" type="email" />
+            <TextInput type="email" />
           </FormField>
 
           <FormField
@@ -109,11 +109,11 @@ const Register = () => {
             name="password"
             required
             validate={[
-              password => {
+              (password) => {
                 if (password && password.length <= 8) return 'Please enter more than 8 characters'
                 return undefined
               },
-              password => {
+              (password) => {
                 const confirmPasswordInput = document.getElementsByName('confirm_password')[0]
                 if (
                   password &&
@@ -126,7 +126,7 @@ const Register = () => {
               },
             ]}
           >
-            <PasswordInput id="password" name="password" />
+            <PasswordInput id="password" />
           </FormField>
 
           <FormField
@@ -134,12 +134,12 @@ const Register = () => {
             name="confirm_password"
             required
             validate={[
-              confirmPassword => {
+              (confirmPassword) => {
                 if (confirmPassword && confirmPassword.length <= 8)
                   return 'Please enter more than 8 characters'
                 return undefined
               },
-              confirmPassword => {
+              (confirmPassword) => {
                 const passwordInput = document.getElementsByName('password')[0]
 
                 if (
@@ -153,12 +153,11 @@ const Register = () => {
               },
             ]}
           >
-            <PasswordInput name="confirm_password" />
+            <PasswordInput />
           </FormField>
 
           <FormField label="Account Type." name="role" required>
             <RadioButtonGroup
-              name="role"
               direction="row"
               gap="xsmall"
               options={[

--- a/app/pages/Register/Register.js
+++ b/app/pages/Register/Register.js
@@ -69,7 +69,7 @@ const Register = () => {
               required
               style={{ flex: 1 }}
               validate={[
-                (name) => {
+                name => {
                   if (name && name.length === 1) return 'Please enter more than one character'
                   return undefined
                 },
@@ -82,7 +82,7 @@ const Register = () => {
               required
               style={{ flex: 1 }}
               validate={[
-                (name) => {
+                name => {
                   if (name && name.length === 1) return 'Please enter more than one character'
                   return undefined
                 },
@@ -95,7 +95,7 @@ const Register = () => {
             name="email"
             required
             validate={[
-              (email) => {
+              email => {
                 if (email && !isEmail(email)) return 'Please enter a valid email address'
                 return undefined
               },
@@ -109,11 +109,11 @@ const Register = () => {
             name="password"
             required
             validate={[
-              (password) => {
+              password => {
                 if (password && password.length <= 8) return 'Please enter more than 8 characters'
                 return undefined
               },
-              (password) => {
+              password => {
                 const confirmPasswordInput = document.getElementsByName('confirm_password')[0]
                 if (
                   password &&
@@ -134,12 +134,12 @@ const Register = () => {
             name="confirm_password"
             required
             validate={[
-              (confirmPassword) => {
+              confirmPassword => {
                 if (confirmPassword && confirmPassword.length <= 8)
                   return 'Please enter more than 8 characters'
                 return undefined
               },
-              (confirmPassword) => {
+              confirmPassword => {
                 const passwordInput = document.getElementsByName('password')[0]
 
                 if (

--- a/app/pages/UserProfile/UserProfile.js
+++ b/app/pages/UserProfile/UserProfile.js
@@ -80,7 +80,7 @@ const UserProfile = () => {
    * Handles changes to all form fields.
    * @param {object} e
    */
-  const handleChange = (e) => {
+  const handleChange = e => {
     const { target, option } = e
 
     setUpdatedUser({
@@ -166,7 +166,7 @@ const UserProfile = () => {
           name="phone"
           value={updatedUser.phone || ''}
           validate={[
-            (phone) => {
+            phone => {
               if (phone && phone.length < 14) return 'Number must be 10 digits'
               return undefined
             },
@@ -197,7 +197,7 @@ const UserProfile = () => {
             ]}
             value={updatedUser.phone || ''}
             validate={[
-              (phone) => {
+              phone => {
                 if (phone && phone.length < 14) return 'Number must be 10 digits'
                 return undefined
               },

--- a/app/pages/UserProfile/UserProfile.js
+++ b/app/pages/UserProfile/UserProfile.js
@@ -80,7 +80,7 @@ const UserProfile = () => {
    * Handles changes to all form fields.
    * @param {object} e
    */
-  const handleChange = e => {
+  const handleChange = (e) => {
     const { target, option } = e
 
     setUpdatedUser({
@@ -124,7 +124,7 @@ const UserProfile = () => {
           serverSideRequired
           value={updatedUser.firstName}
         >
-          <TextInput name="firstName" value={updatedUser.firstName} />
+          <TextInput value={updatedUser.firstName} />
         </AutoSaveFormField>
 
         <AutoSaveFormField
@@ -135,7 +135,7 @@ const UserProfile = () => {
           serverSideRequired
           value={updatedUser.lastName}
         >
-          <TextInput name="lastName" value={updatedUser.lastName} />
+          <TextInput value={updatedUser.lastName} />
         </AutoSaveFormField>
 
         {/* We don't support the user changing their email address yet, so this is
@@ -156,7 +156,7 @@ const UserProfile = () => {
           ]}
           value={updatedUser.email}
         >
-          <TextInput disabled name="email" value={updatedUser.email} />
+          <TextInput disabled value={updatedUser.email} />
         </AutoSaveFormField>
 
         <AutoSaveFormField
@@ -166,7 +166,7 @@ const UserProfile = () => {
           name="phone"
           value={updatedUser.phone || ''}
           validate={[
-            phone => {
+            (phone) => {
               if (phone && phone.length < 14) return 'Number must be 10 digits'
               return undefined
             },
@@ -195,10 +195,9 @@ const UserProfile = () => {
                 placeholder: 'xxxx',
               },
             ]}
-            name="phone"
             value={updatedUser.phone || ''}
             validate={[
-              phone => {
+              (phone) => {
                 if (phone && phone.length < 14) return 'Number must be 10 digits'
                 return undefined
               },


### PR DESCRIPTION
## Feature

- Only require setting the `name` on the `FormField`

## Approach

- Pass down the `name` prop to children
- Remove `name` from all form inputs

## Resources

- https://reactjs.org/docs/react-api.html

<!-- include this section for staging releases
## Changelog (Staging / Internal)
-
-->

<!-- include this section for production releases
## Release Notes (App Store)
-

## Full Changelog (Release)
### <Build Number
-
-->
